### PR TITLE
typecast user id to string, since the function parameter requires it

### DIFF
--- a/src/Service/Action/Auth/JwtTokenTrait.php
+++ b/src/Service/Action/Auth/JwtTokenTrait.php
@@ -72,7 +72,7 @@ trait JwtTokenTrait
             ->issuedAt($timestamp) // Configures the time that the token was issue (iat claim)
             ->permittedFor($audience) // Configures the audience (aud claim)
             ->expiresAt($this->accessTokenLifeTime($timestamp)) // Configures the expiration time of the token (nbf claim)
-            ->relatedTo($subject) // Configures a new claim, called "sub"
+            ->relatedTo((string)$subject) // Configures a new claim, called "sub"
             ->getToken($config->signer(), $config->signingKey()); // Retrieves the generated token
 
         return $token->toString();


### PR DESCRIPTION
Type cast user id, since the `relatedTo` paremeter is required as `string`