### PR TITLE
#fix security vulnerability in firebase/php-jwt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "cakephp/cakephp": "^4.3",
         "cakedc/users": "^11.0",
         "lcobucci/jwt": "~4.0.0",
-        "firebase/php-jwt": "^5.0"
+        "firebase/php-jwt": "^6.2"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^4.0",


### PR DESCRIPTION
The required version of the firebase/php-jwt plugin contains a critical security vulnerability that is resolved in version 6.0

https://github.com/advisories/GHSA-8xf4-w7qw-pjjw
https://github.com/firebase/php-jwt/releases/tag/v6.0.0