### PR TITLE
#fix security vulnerability in firebase/php-jwt and fix tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "cakephp/cakephp": "^4.3",
         "cakedc/users": "^11.0",
         "lcobucci/jwt": "~4.0.0",
-        "firebase/php-jwt": "^5.0"
+        "firebase/php-jwt": "^6.2"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "~4.4.0",

--- a/src/Service/Renderer/FlysystemRenderer.php
+++ b/src/Service/Renderer/FlysystemRenderer.php
@@ -19,11 +19,11 @@ use Cake\Log\LogTrait;
 use Cake\Utility\Hash;
 use CakeDC\Api\Service\Action\Result;
 use Exception;
+use Laminas\Diactoros\Stream;
 use League\Flysystem\File;
 use League\Flysystem\FileNotFoundException;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Handler;
-use Zend\Diactoros\Stream;
 
 /**
  * Class FlysystemRenderer to render file using Flysystem library

--- a/tests/TestCase/Service/Renderer/FlysystemRendererTest.php
+++ b/tests/TestCase/Service/Renderer/FlysystemRendererTest.php
@@ -88,7 +88,7 @@ class FlysystemRendererTest extends TestCase
      */
     public function testRendererSuccess()
     {
-        Configure::write('debug', 0);
+        Configure::write('debug', false);
         Configure::write('Api.Flysystem.expire', '+1 day');
 
         $response = $this
@@ -138,7 +138,7 @@ class FlysystemRendererTest extends TestCase
      */
     public function testRendereFileNotFound()
     {
-        Configure::write('debug', 0);
+        Configure::write('debug', false);
         $response = $this
             ->getMockBuilder(\Cake\Http\Response::class)
             ->setMethods(['withStatus', 'withType', 'withStringBody'])


### PR DESCRIPTION
The required version of the firebase/php-jwt plugin contains a critical security vulnerability that is resolved in version 6.0

https://github.com/advisories/GHSA-8xf4-w7qw-pjjw
https://github.com/firebase/php-jwt/releases/tag/v6.0.0