### PR TITLE
 JWT::decode() Compatibility with firebase/php-jwt:v6.9.0

### DIFF
--- a/src/Service/Auth/Authenticate/JwtAuthenticate.php
+++ b/src/Service/Auth/Authenticate/JwtAuthenticate.php
@@ -12,6 +12,7 @@ use Cake\Utility\Security;
 use CakeDC\Api\Service\Action\Action;
 use Exception;
 use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 
 /**
  * An authentication adapter for authenticating using JSON Web Tokens.
@@ -102,7 +103,7 @@ class JwtAuthenticate extends BaseAuthenticate
         $this->setConfig($config);
 
         if (empty($config['allowedAlgs'])) {
-            $config['allowedAlgs'] = ['HS512'];
+            $config['allowedAlgs'] = 'HS512';
         }
 
         parent::__construct($action, $config);
@@ -221,8 +222,7 @@ class JwtAuthenticate extends BaseAuthenticate
         try {
             return JWT::decode(
                 $token,
-                $config['key'] ?: Security::getSalt(),
-                $config['allowedAlgs']
+                new Key($config['key'] ?: Security::getSalt(), $config['allowedAlgs'])
             );
         } catch (Exception $e) {
             if (Configure::read('debug')) {


### PR DESCRIPTION
HI,
the third parameter JWT::decode() in firebase/php-jwt:v6.9.0 is changed.
With these changes, I tried to solve this incompatibility problem.
I hope I have done this correctly.
--------
and I apologize for the multiple request for pull request :)