### PR TITLE
Fix JWT dependency in  cake 4 with kreait/firebase-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "ext-json": "*",
         "cakephp/cakephp": "^4.3",
         "cakedc/users": "^11.0",
-        "lcobucci/jwt": "~4.0.0",
+        "lcobucci/jwt": "^4.0",
         "firebase/php-jwt": "^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
 JWT dependency in 9.x-cake4.3 has conflict with kreait/firebase-php:7.0

```
 Running composer update kreait/firebase-php --with-all-dependencies
 Loading composer repositories with package information
 Updating dependencies
 Your requirements could not be resolved to an installable set of packages.
 
   Problem 1
     - Root composer.json requires cakedc/cakephp-api ^9.1 -> satisfiable by cakedc/cakephp-api[9.1.0, ..., 9.1.9].
     - Root composer.json requires kreait/firebase-php ^7.0 -> satisfiable by kreait/firebase-php[7.0.0, ..., 7.15.0].
     - cakedc/cakephp-api[9.1.0, ..., 9.1.9] require lcobucci/jwt ~4.0.0 -> satisfiable by lcobucci/jwt[4.0.0, ..., 4.0.4].
     - Conclusion: don't install lcobucci/jwt 4.0.4 (conflict analysis result)
```