### PR TITLE
fix the testSuccessRegister test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "php": ">=8.1",
         "ext-json": "*",
         "cakephp/cakephp": "^5.0",
-        "cakedc/users": "^12.0",
+        "cakedc/users": "^14.3",
         "lcobucci/jwt": "~4.0.0",
         "firebase/php-jwt": "^6.3"
     },

--- a/tests/TestCase/Integration/Service/Action/Auth/RegisterActionTest.php
+++ b/tests/TestCase/Integration/Service/Action/Auth/RegisterActionTest.php
@@ -81,7 +81,7 @@ class RegisterActionTest extends IntegrationTestCase
             'role' => 'user',
         ];
         $data = $result['data'];
-        unset($data['id'], $data['tos_date']);
+        unset($data['id'], $data['tos_date'], $data['last_login'], $data['secret_verified']);
         $this->assertEquals($expected, $data);
     }
 


### PR DESCRIPTION
Two values ('_last_login_' and '_secret_verified_') was missing from the validation test and where added to the unset call to match the expected array.  Fixing the _testSuccessRegister()_

`unset($data['id'], $data['tos_date'], $data['last_login'], $data['secret_verified']);`

